### PR TITLE
Add comprehensive test cases for bitwise operations in bit_op.h

### DIFF
--- a/test/prec/test_core.cpp
+++ b/test/prec/test_core.cpp
@@ -532,7 +532,62 @@ int main(int argc, char const *argv[]) {
 			},
 			special_opt
 		);
+    // ---------------------------------
+    // Bit Operation Test Cases Section
+    // ---------------------------------
+    
+    {
+        uint64_t a = 0xFFFFFFFFFFFFFFFF;
+        uint64_t b = 0x2;
+        uint64_t c_low, c_high;
 
+        uint64_t expected_low = 0xFFFFFFFFFFFFFFFE;
+        uint64_t expected_high = 0x1;
+
+        th::mul_uint128(a, b, c_low, c_high);
+
+        prec::equals("th::mul_uint128 (c_low)", c_low, expected_low);
+        prec::equals("th::mul_uint128 (c_high)", c_high, expected_high);
+    }
+
+    {
+        uint64_t a = 0x12345678ABCDEF00;
+        uint64_t b = 0x0FEDCBA987654321;
+        
+        uint64_t result = th::mix_mum(a, b);
+        
+        prec::equals("th::mix_mum non-zero result", result != 0, true);
+    }
+
+    {
+        uint64_t x = 0x12345678ABCDEF00;
+        unsigned int i = 8;
+        uint64_t rotated = th::bit_rotate(x, i);
+
+        uint64_t expected_rotated = 0x345678ABCDEF0012;
+
+        prec::equals("th::bit_rotate (64-bit)", rotated, expected_rotated);
+    }
+
+    {
+        uint32_t x = 0xABCDEF00;
+        unsigned int i = 4;
+        uint32_t rotated = theoretica::bit_rotate(x, i);
+
+        uint32_t expected_rotated = 0xBCDEF00A;
+
+        prec::equals("th::bit_rotate (32-bit)", rotated, expected_rotated);
+    }
+
+    {
+        std::vector<uint8_t> vec = {1, 2, 3, 4};
+        
+        theoretica::swap_bit_reverse(vec, 2);
+
+        std::vector<uint8_t> expected = {1, 3, 2, 4};
+
+        prec::equals("th::swap_bit_reverse", vec == expected, true);
+    }
 
 	prec::terminate();
 }


### PR DESCRIPTION
## Description
Hello! I’ve added test cases for the bitwise operations in bit_op.h to ensure they function correctly and match expected results. This pull request is intended as a preliminary submission to confirm that my approach aligns with the testing standards for this repository.

I plan to continue writing test cases for the core module as well all the other modules, so I would appreciate any feedback you may have on these initial tests. This will help me make improvements before proceeding with further contributions.

Thank you for reviewing my work!
