### PR TITLE
Change results of iterative algorithms to include convergence information

### DIFF
--- a/src/core/iter_result.h
+++ b/src/core/iter_result.h
@@ -1,0 +1,168 @@
+
+///
+/// @file iter_result.h Structured results for iterative algorithms, containing information about convergence.
+///
+
+#ifndef THEORETICA_ITER_RESULT_H
+#define THEORETICA_ITER_RESULT_H
+
+#include <string>
+#include "./constants.h"
+#include "./error.h"
+
+
+namespace theoretica {
+
+
+	/// @enum ConvergenceStatus
+	/// Status codes for iterative algorithm termination
+	enum class ConvergenceStatus {
+
+		/// Algorithm converged successfully
+		Success,
+
+		/// Maximum iterations exceeded
+		MaxIterations,
+
+		/// No progress in iterations
+		Stalled,
+
+		/// Invalid input provided
+		InvalidInput,   
+		
+		/// Algorithm diverged
+		Diverged,
+
+		/// User terminated early
+		UserInterrupt
+	};
+
+
+	/// @class iter_result
+	/// A structure returned by iterative algorithms containing
+	/// the computed value, convergence information, and diagnostics.
+	///
+	/// Features implicit conversion to the result type.
+	/// @tparam T The type of the computed result (usually real or vec<real, N>)
+	template<typename Type = real>
+	struct iter_result {
+
+		/// The computed result value
+		Type value;
+
+		/// Whether the algorithm converged within the specified criteria
+		bool converged = false;
+
+		/// Status code indicating reason for termination
+		ConvergenceStatus status = ConvergenceStatus::Success;
+
+		/// Number of iterations performed
+		unsigned int iterations = 0;
+
+		/// Final error or residual norm (exact meaning depends on the algorithm)
+		real residual = inf();
+
+
+		/// Constructor with default values
+		iter_result() : value(Type(nan())) {}
+
+
+		/// Constructor with value for reporting success
+		iter_result(const Type& val) : value(val) {
+			converged = true;
+			status = ConvergenceStatus::Success;
+		}
+		
+		iter_result(const Type& value, unsigned int iterations)
+		: value(value), iterations(iterations) {
+			converged = true;
+			status = ConvergenceStatus::Success;
+		}
+
+		iter_result(const Type& value, unsigned int iterations, real residual)
+		: value(value), iterations(iterations), residual(residual) {
+			converged = true;
+			status = ConvergenceStatus::Success;
+		}
+
+
+		/// Constructor with convergence status for reporting failure
+		iter_result(ConvergenceStatus status, unsigned int iterations = 0)
+		: status(status), iterations(iterations) {
+			value = Type(nan());
+			converged = false;
+		}
+
+		iter_result(ConvergenceStatus status, unsigned int iterations, real residual)
+		: status(status), iterations(iterations), residual(residual) {
+			value = Type(nan());
+			converged = false;
+		}
+
+
+		/// Implicit conversion to result type, allows code like: Type res = algorithm();
+		operator Type() const {
+			return value;
+		}
+
+		/// Explicit conversion to boolean (converged status), allows code like: if (result) { ... }
+		explicit operator bool() const {
+			return converged;
+		}
+
+
+		/// Get a human-readable string description of the status of convergence of an iterative algorithm.
+		inline std::string status_string() const {
+
+			switch(status) {
+				case ConvergenceStatus::Success: 
+					return "Converged successfully";
+				case ConvergenceStatus::MaxIterations:
+					return "Maximum iterations exceeded without converging to desired accuracy";
+				case ConvergenceStatus:: Stalled:
+					return "Algorithm stalled";
+				case ConvergenceStatus::InvalidInput:
+					return "Invalid input provided";
+				case ConvergenceStatus::Diverged:
+					return "Algorithm diverged";
+				case ConvergenceStatus::UserInterrupt: 
+					return "User interrupt";
+				default:
+					return "Unknown status";
+			}
+		}
+
+		
+#ifndef THEORETICA_NO_PRINT
+
+		/// Convert the iter_result number to string representation
+		inline std::string to_string() const {
+
+			std::stringstream res;
+
+			res << "Value = " << value << "\n";
+
+			if (!converged)
+				res << "Converged = " << (converged ? "true" : "false") << "\n";
+
+			res << "Status: " << status_string() << "\n";
+			res << "Iterations = " << iterations << "\n";
+			res << "Residual = " << residual;
+
+			return res.str();
+		}
+
+
+		/// Stream the complex number in string representation
+		/// to an output stream (std::ostream)
+		inline friend std::ostream& operator<<(std::ostream& out, const iter_result<Type>& obj) {
+			return out << obj.to_string();
+		}
+
+#endif
+
+	};
+
+}
+
+#endif

--- a/src/core/iter_result.h
+++ b/src/core/iter_result.h
@@ -44,11 +44,8 @@ namespace theoretica {
 	template<typename Type = real>
 	struct iter_result {
 
-		/// The computed result value
+		/// Best estimate of the result
 		Type value;
-
-		/// Whether the algorithm converged within the specified criteria
-		bool converged = false;
 
 		/// Status code indicating reason for termination
 		ConvergenceStatus status = ConvergenceStatus::Success;
@@ -60,51 +57,57 @@ namespace theoretica {
 		real residual = inf();
 
 
-		/// Constructor with default values
+		/// Construct with default values
 		iter_result() : value(Type(nan())) {}
 
 
-		/// Constructor with value for reporting success
+		/// Construct with final result for reporting success
 		iter_result(const Type& val) : value(val) {
-			converged = true;
 			status = ConvergenceStatus::Success;
 		}
 		
+		/// Construct with final result for reporting success
 		iter_result(const Type& value, unsigned int iterations)
 		: value(value), iterations(iterations) {
-			converged = true;
+
 			status = ConvergenceStatus::Success;
 		}
 
+		/// Construct with final result for reporting success
 		iter_result(const Type& value, unsigned int iterations, real residual)
 		: value(value), iterations(iterations), residual(residual) {
-			converged = true;
+
 			status = ConvergenceStatus::Success;
 		}
 
 
-		/// Constructor with convergence status for reporting failure
+		/// Construct with convergence status for reporting failure
 		iter_result(ConvergenceStatus status, unsigned int iterations = 0)
 		: status(status), iterations(iterations) {
 			value = Type(nan());
-			converged = false;
 		}
 
+		/// Construct with convergence status for reporting failure
 		iter_result(ConvergenceStatus status, unsigned int iterations, real residual)
 		: status(status), iterations(iterations), residual(residual) {
 			value = Type(nan());
-			converged = false;
 		}
 
 
-		/// Implicit conversion to result type, allows code like: Type res = algorithm();
+		/// Implicit conversion to result type, allows code like:
+		/// Type res = algorithm();
 		operator Type() const {
 			return value;
 		}
 
+		/// Check if the algorithm converged successfully
+		inline bool converged() const {
+			return status == ConvergenceStatus::Success;
+		}
+
 		/// Explicit conversion to boolean (converged status), allows code like: if (result) { ... }
 		explicit operator bool() const {
-			return converged;
+			return converged();
 		}
 
 

--- a/src/core/iter_result.h
+++ b/src/core/iter_result.h
@@ -31,10 +31,7 @@ namespace theoretica {
 		InvalidInput,   
 		
 		/// Algorithm diverged
-		Diverged,
-
-		/// User terminated early
-		UserInterrupt
+		Diverged
 	};
 
 
@@ -125,8 +122,6 @@ namespace theoretica {
 					return "Invalid input provided";
 				case ConvergenceStatus::Diverged:
 					return "Algorithm diverged";
-				case ConvergenceStatus::UserInterrupt: 
-					return "User interrupt";
 				default:
 					return "Unknown status";
 			}

--- a/src/core/iter_result.h
+++ b/src/core/iter_result.h
@@ -105,7 +105,8 @@ namespace theoretica {
 			return status == ConvergenceStatus::Success;
 		}
 
-		/// Explicit conversion to boolean (converged status), allows code like: if (result) { ... }
+		/// Explicit conversion to boolean (converged status), allows code like:
+		/// if (result) { ... }
 		explicit operator bool() const {
 			return converged();
 		}
@@ -139,10 +140,6 @@ namespace theoretica {
 			std::stringstream res;
 
 			res << "Value = " << value << "\n";
-
-			if (!converged)
-				res << "Converged = " << (converged ? "true" : "false") << "\n";
-
 			res << "Status: " << status_string() << "\n";
 			res << "Iterations = " << iterations << "\n";
 			res << "Residual = " << residual;

--- a/src/optimization/extrema.h
+++ b/src/optimization/extrema.h
@@ -21,11 +21,14 @@ namespace theoretica {
 	/// @param b The upper extreme of the search interval.
 	/// @return The coordinate of the local maximum.
 	template<typename RealFunction>
-	inline real maximize_goldensection(RealFunction f, real a, real b) {
+	inline iter_result<real> maximize_goldensection(
+		RealFunction f, real a, real b,
+		real tolerance = OPTIMIZATION_TOL,
+		unsigned int max_iter = OPTIMIZATION_GOLDENSECTION_ITER) {
 
 		if(a > b) {
 			TH_MATH_ERROR("maximize_goldensection", b, MathError::InvalidArgument);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::InvalidInput);
 		}
 
 		real x1 = a;
@@ -35,7 +38,9 @@ namespace theoretica {
 
 		unsigned int iter = 0;
 
-		while(abs(x2 - x1) > OPTIMIZATION_TOL && iter <= OPTIMIZATION_GOLDENSECTION_ITER) {
+		// Keep iterating until the bracketing interval is closer than the tolerance,
+		// or until the maximum number of iterations is reached.
+		while(abs(x2 - x1) > tolerance && iter <= max_iter) {
 
 			if(f(x3) > f(x4)) {
 				x2 = x4;
@@ -49,12 +54,12 @@ namespace theoretica {
 			iter++;
 		}
 
-		if(iter > OPTIMIZATION_GOLDENSECTION_ITER) {
+		if(iter > max_iter) {
 			TH_MATH_ERROR("maximize_goldensection", iter, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(x2 - x1) / 2.0);
 		}
 
-		return (x2 + x1) / 2.0;
+		return iter_result<real>((x2 + x1) / 2.0, iter, abs(x2 - x1) / 2.0);
 	}
 
 
@@ -66,11 +71,14 @@ namespace theoretica {
 	/// @param b The upper extreme of the search interval.
 	/// @return The coordinate of the local minimum.
 	template<typename RealFunction>
-	inline real minimize_goldensection(RealFunction f, real a, real b) {
+	inline iter_result<real> minimize_goldensection(
+		RealFunction f, real a, real b,
+		real tolerance = OPTIMIZATION_TOL,
+		unsigned int max_iter = OPTIMIZATION_GOLDENSECTION_ITER) {
 
 		if(a > b) {
 			TH_MATH_ERROR("minimize_goldensection", b, MathError::InvalidArgument);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::InvalidInput);
 		}
 
 		real x1 = a;
@@ -80,7 +88,7 @@ namespace theoretica {
 
 		unsigned int iter = 0;
 
-		while(abs(x2 - x1) > OPTIMIZATION_TOL && iter <= OPTIMIZATION_GOLDENSECTION_ITER) {
+		while(abs(x2 - x1) > tolerance && iter <= max_iter) {
 
 			if(f(x3) < f(x4)) {
 				x2 = x4;
@@ -94,12 +102,12 @@ namespace theoretica {
 			iter++;
 		}
 
-		if(iter > OPTIMIZATION_GOLDENSECTION_ITER) {
+		if(iter > max_iter) {
 			TH_MATH_ERROR("minimize_goldensection", iter, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(x2 - x1) / 2.0);
 		}
 
-		return (x2 + x1) / 2.0;
+		return iter_result<real>((x2 + x1) / 2.0, iter, abs(x2 - x1) / 2.0);
 	}
 
 
@@ -113,18 +121,19 @@ namespace theoretica {
 	/// @param guess The initial guess (defaults to 0).
 	/// @return The coordinate of the local maximum.
 	template<typename RealFunction>
-	inline real maximize_newton(
+	inline iter_result<real> maximize_newton(
 		RealFunction f, RealFunction Df, RealFunction D2f,
-		real guess = 0) {
+		real guess = 0.0, real tolerance = OPTIMIZATION_TOL,
+		unsigned int max_iter = OPTIMIZATION_NEWTON_ITER) {
 
-		real z = root_newton(Df, D2f, guess);
+		iter_result<real> z = root_newton(Df, D2f, guess, tolerance, max_iter);
 
 		if(D2f(z) > 0) {
 			TH_MATH_ERROR("maximize_newton", z, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(z.status, z.iterations, z.residual);
 		}
 
-		return z;
+		return iter_result<real>(z, z.iterations, z.residual);
 	}
 
 
@@ -138,18 +147,20 @@ namespace theoretica {
 	/// @param guess The initial guess (defaults to 0).
 	/// @return The coordinate of the local minimum.
 	template<typename RealFunction>
-	inline real minimize_newton(
+	inline iter_result<real> minimize_newton(
 		RealFunction f, RealFunction Df,
-		RealFunction D2f, real guess = 0) {
+		RealFunction D2f, real guess = 0,
+		real tolerance = OPTIMIZATION_TOL,
+		unsigned int max_iter = OPTIMIZATION_NEWTON_ITER) {
 
-		real z = root_newton(Df, D2f, guess);
+		iter_result<real> z = root_newton(Df, D2f, guess, tolerance, max_iter);
 
 		if(D2f(z) < 0) {
 			TH_MATH_ERROR("minimize_newton", z, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(z.status, z.iterations, z.residual);
 		}
 
-		return z;
+		return iter_result<real>(z, z.iterations, z.residual);
 	}
 
 
@@ -163,18 +174,20 @@ namespace theoretica {
 	/// @param b The upper extreme of the search interval.
 	/// @return The coordinate of the local maximum.
 	template<typename RealFunction>
-	inline real maximize_bisection(
+	inline iter_result<real> maximize_bisection(
 		RealFunction f, RealFunction Df,
-		real a, real b) {
+		real a, real b,
+		real tolerance = OPTIMIZATION_TOL,
+		unsigned int max_iter = OPTIMIZATION_BISECTION_ITER) {
 
-		real z = root_bisect(Df, a, b);
+		iter_result<real> z = root_bisect(Df, a, b, tolerance, max_iter);
 
 		if(deriv_central(Df, z) > 0) {
 			TH_MATH_ERROR("maximize_bisection", z, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(z.status, z.iterations, z.residual);
 		}
 
-		return z;
+		return iter_result<real>(z, z.iterations, z.residual);
 	}
 
 
@@ -188,16 +201,19 @@ namespace theoretica {
 	/// @param b The upper extreme of the search interval.
 	/// @return The coordinate of the local minimum.
 	template<typename RealFunction>
-	inline real minimize_bisection(RealFunction f, RealFunction Df, real a, real b) {
+	inline iter_result<real> minimize_bisection(
+		RealFunction f, RealFunction Df, real a, real b,
+		real tolerance = OPTIMIZATION_TOL,
+		unsigned int max_iter = OPTIMIZATION_BISECTION_ITER) {
 
-		real z = root_bisect(Df, a, b);
+		iter_result<real> z = root_bisect(Df, a, b, tolerance, max_iter);
 
 		if(deriv_central(Df, z) < 0) {
 			TH_MATH_ERROR("minimize_bisection", z, MathError::NoConvergence);
-			return z;
+			return iter_result<real>(z.status, z.iterations, z.residual);
 		}
 
-		return z;
+		return iter_result<real>(z, z.iterations, z.residual);
 	}
 
 }

--- a/src/optimization/extrema.h
+++ b/src/optimization/extrema.h
@@ -21,13 +21,13 @@ namespace theoretica {
 	/// @param b The upper extreme of the search interval.
 	/// @return The coordinate of the local maximum.
 	template<typename RealFunction>
-	inline iter_result<real> maximize_goldensection(
+	inline iter_result<real> maximize_golden(
 		RealFunction f, real a, real b,
 		real tolerance = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_GOLDENSECTION_ITER) {
 
 		if(a > b) {
-			TH_MATH_ERROR("maximize_goldensection", b, MathError::InvalidArgument);
+			TH_MATH_ERROR("maximize_golden", b, MathError::InvalidArgument);
 			return iter_result<real>(ConvergenceStatus::InvalidInput);
 		}
 
@@ -55,7 +55,7 @@ namespace theoretica {
 		}
 
 		if(iter > max_iter) {
-			TH_MATH_ERROR("maximize_goldensection", iter, MathError::NoConvergence);
+			TH_MATH_ERROR("maximize_golden", iter, MathError::NoConvergence);
 			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(x2 - x1) / 2.0);
 		}
 
@@ -111,7 +111,7 @@ namespace theoretica {
 	}
 
 
-	/// Approximate a function maximum given the function and the
+	/// Approximate a function maximum given the function and its
 	/// first two derivatives using Newton-Raphson's method
 	/// to find a root of the derivative.
 	///
@@ -128,9 +128,18 @@ namespace theoretica {
 
 		iter_result<real> z = root_newton(Df, D2f, guess, tolerance, max_iter);
 
-		if(D2f(z) > 0) {
+		if(D2f(z) < 0) {
+			
 			TH_MATH_ERROR("maximize_newton", z, MathError::NoConvergence);
-			return iter_result<real>(z.status, z.iterations, z.residual);
+
+			// If the root finding algorithm converged but found a solution
+			// with the wrong concavity (minimum instead of maximum),
+			// mark the status as diverged.
+			return iter_result<real>(
+				(z.status == ConvergenceStatus::Success) ? ConvergenceStatus::Diverged : z.status,
+				z.iterations,
+				z.residual
+			);
 		}
 
 		return iter_result<real>(z, z.iterations, z.residual);
@@ -138,7 +147,7 @@ namespace theoretica {
 
 
 	/// Approximate a function minimum given the function
-	/// and the first two derivatives using Newton-Raphson's
+	/// and its first two derivatives using Newton-Raphson's
 	/// method to find a root of the derivative.
 	///
 	/// @param f The function to search a local minimum of.
@@ -155,9 +164,18 @@ namespace theoretica {
 
 		iter_result<real> z = root_newton(Df, D2f, guess, tolerance, max_iter);
 
-		if(D2f(z) < 0) {
+		if(D2f(z) > 0) {
+
 			TH_MATH_ERROR("minimize_newton", z, MathError::NoConvergence);
-			return iter_result<real>(z.status, z.iterations, z.residual);
+
+			// If the root finding algorithm converged but found a solution
+			// with the wrong concavity (maximum instead of minimum),
+			// mark the status as diverged.
+			return iter_result<real>(
+				(z.status == ConvergenceStatus::Success) ? ConvergenceStatus::Diverged : z.status,
+				z.iterations,
+				z.residual
+			);
 		}
 
 		return iter_result<real>(z, z.iterations, z.residual);
@@ -182,9 +200,19 @@ namespace theoretica {
 
 		iter_result<real> z = root_bisect(Df, a, b, tolerance, max_iter);
 
-		if(deriv_central(Df, z) > 0) {
+		// Approximate the function concavity
+		if(deriv_central(Df, z) < 0) {
+
 			TH_MATH_ERROR("maximize_bisection", z, MathError::NoConvergence);
-			return iter_result<real>(z.status, z.iterations, z.residual);
+
+			// If the root finding algorithm converged but found a solution
+			// with the wrong concavity (minimum instead of maximum),
+			// mark the status as diverged.
+			return iter_result<real>(
+				(z.status == ConvergenceStatus::Success) ? ConvergenceStatus::Diverged : z.status,
+				z.iterations,
+				z.residual
+			);
 		}
 
 		return iter_result<real>(z, z.iterations, z.residual);
@@ -201,16 +229,26 @@ namespace theoretica {
 	/// @param b The upper extreme of the search interval.
 	/// @return The coordinate of the local minimum.
 	template<typename RealFunction>
-	inline iter_result<real> minimize_bisection(
+	inline iter_result<real> minimize_bisect(
 		RealFunction f, RealFunction Df, real a, real b,
 		real tolerance = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_BISECTION_ITER) {
 
 		iter_result<real> z = root_bisect(Df, a, b, tolerance, max_iter);
 
-		if(deriv_central(Df, z) < 0) {
-			TH_MATH_ERROR("minimize_bisection", z, MathError::NoConvergence);
-			return iter_result<real>(z.status, z.iterations, z.residual);
+		// Approximate the function concavity
+		if(deriv_central(Df, z) > 0) {
+
+			TH_MATH_ERROR("minimize_bisect", z, MathError::NoConvergence);
+
+			// If the root finding algorithm converged but found a solution
+			// with the wrong concavity (maximum instead of minimum),
+			// mark the status as diverged.
+			return iter_result<real>(
+				(z.status == ConvergenceStatus::Success) ? ConvergenceStatus::Diverged : z.status,
+				z.iterations,
+				z.residual
+			);
 		}
 
 		return iter_result<real>(z, z.iterations, z.residual);

--- a/src/optimization/multi_extrema.h
+++ b/src/optimization/multi_extrema.h
@@ -165,7 +165,7 @@ namespace theoretica {
 
 			// Maximize f(x + gamma * gradient) in [-1, 0]
 			// using Golden Section extrema search
-			real gamma = maximize_goldensection(
+			real gamma = maximize_golden(
 				[f, x, grad](real gamma){
 					return f(multidual<N>::make_argument(x + gamma * grad)).Re();
 				}, -1, 0);

--- a/src/optimization/roots.h
+++ b/src/optimization/roots.h
@@ -14,7 +14,6 @@
 #include "../complex/complex.h"
 #include "../core/iter_result.h"
 
-#include <iostream>
 
 namespace theoretica {
 
@@ -26,12 +25,14 @@ namespace theoretica {
 	/// @param a The lower extreme of the interval
 	/// @param b The upper extreme of the interval
 	/// @param steps The number of sub-intervals to check (defaults to 10)
+	/// @return A vector of pairs of real numbers, where each pair (x1, x2)
+	/// represents a bracketing interval potentially containing a root.
 	template<typename RealFunction, typename Bracket = vec2>
-	inline std::vector<Bracket> find_root_intervals(
+	inline std::vector<Bracket> find_root_brackets(
 		RealFunction f, real a, real b, unsigned int steps = 10) {
 
 		std::vector<Bracket> res;
-		const real dx = (b - a) / (real) steps;
+		const real dx = (b - a) / steps;
 
 		for (unsigned int i = 0; i < steps; ++i) {
 			
@@ -667,10 +668,10 @@ namespace theoretica {
 		}
 
 		// Find candidate intervals
-		auto intervals = find_root_intervals(f, a, b, steps);
+		auto intervals = find_root_brackets(f, a, b, steps);
 
 		Vector res;
-		res.resize(intervals.size());
+		res.resize(intervals.size(), nan());
 		size_t idx = 0;
 
 		// Iterate through all candidate intervals and refine the results
@@ -699,8 +700,6 @@ namespace theoretica {
 			}
 		}
 
-		// Remove extra elements
-		//res.resize(idx);
 		return res;
 	}
 

--- a/src/optimization/roots.h
+++ b/src/optimization/roots.h
@@ -14,6 +14,7 @@
 #include "../complex/complex.h"
 #include "../core/iter_result.h"
 
+#include <iostream>
 
 namespace theoretica {
 
@@ -25,11 +26,11 @@ namespace theoretica {
 	/// @param a The lower extreme of the interval
 	/// @param b The upper extreme of the interval
 	/// @param steps The number of sub-intervals to check (defaults to 10)
-	template<typename RealFunction, typename Vector = vec2>
-	inline std::vector<Vector> find_root_intervals(
+	template<typename RealFunction, typename Bracket = vec2>
+	inline std::vector<Bracket> find_root_intervals(
 		RealFunction f, real a, real b, unsigned int steps = 10) {
 
-		std::vector<Vector> res;
+		std::vector<Bracket> res;
 		const real dx = (b - a) / (real) steps;
 
 		for (unsigned int i = 0; i < steps; ++i) {
@@ -56,19 +57,19 @@ namespace theoretica {
 	/// @return The coordinate of the root of the function,
 	/// or NaN if the algorithm did not converge.
 	template<typename RealFunction>
-	inline real root_bisect(
+	inline iter_result<real> root_bisect(
 		RealFunction f, real a, real b,
 		real tol = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_BISECTION_ITER) {
 
 		if(a > b) {
 			TH_MATH_ERROR("root_bisect", a, MathError::InvalidArgument);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::InvalidInput);
 		}
 
 		if(f(a) * f(b) >= 0) {
 			TH_MATH_ERROR("root_bisect", f(a) * f(b), MathError::InvalidArgument);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::InvalidInput);
 		}
 
 		real x_avg = 0.0;
@@ -91,10 +92,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_bisect", x_avg, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(b - a) / 2.0);
 		}
 
-		return x_avg;
+		return iter_result<real>(x_avg, iter, abs(b - a) / 2.0);
 	}
 
 
@@ -128,7 +129,7 @@ namespace theoretica {
 
 		if(a > b) {
 			TH_MATH_ERROR("root_itp", a, MathError::InvalidArgument);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::InvalidInput);
 		}
 
 		real y_a = f(a);
@@ -136,7 +137,7 @@ namespace theoretica {
 
 		if(y_a * y_b >= 0) {
 			TH_MATH_ERROR("root_itp", y_a * y_b, MathError::InvalidArgument);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::InvalidInput);
 		}
 
 		// Monotonicity of the function
@@ -196,10 +197,10 @@ namespace theoretica {
 
 		if(abs(b - a) > 2 * tol) {
 			TH_MATH_ERROR("root_itp", (a + b) / 2.0, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(b - a) / 2.0);
 		}
 
-		return (a + b) / 2.0;
+		return iter_result<real>((a + b) / 2.0, iter, abs(b - a) / 2.0);
 	}
 
 
@@ -230,8 +231,8 @@ namespace theoretica {
 
 			// Check for division by zero
 			if (abs(Df_x) < MACH_EPSILON) {
-				TH_MATH_ERROR("root_newton", Df_x, DIV_BY_ZERO);
-				return iter_result<real>(ConvergenceStatus::Diverged, iter, Df_x);
+				TH_MATH_ERROR("root_newton", Df_x, MathError::DivByZero);
+				return iter_result<real>(ConvergenceStatus::Diverged, iter, f_x);
 			}
 
 			f_x = f(x);
@@ -241,10 +242,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_newton", x, MathError::NoConvergence);
-			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, Df_x);
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(f_x));
 		}
 
-		return iter_result<real>(x, iter, f_x);
+		return iter_result<real>(x, iter, abs(f_x));
 	}
 
 
@@ -260,15 +261,14 @@ namespace theoretica {
 	/// the algorithm is assumed to not have converged.
 	/// @return The coordinate of the root of the function,
 	/// or NaN if the algorithm did not converge.
-	inline real root_newton(
+	inline iter_result<real> root_newton(
 		dual(*f)(dual), real guess = 0,
 		real tol = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_NEWTON_ITER) {
 
 		real x = guess;
-		unsigned int iter = 0;
-
 		dual s = dual(inf(), 0.0);
+		unsigned int iter = 0;
 
 		while(abs(s.Re()) > tol && iter <= max_iter) {
 
@@ -281,10 +281,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_newton", x, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(s.Re()));
 		}
 
-		return x;
+		return iter_result<real>(x, iter, abs(s.Re()));
 	}
 
 
@@ -303,7 +303,7 @@ namespace theoretica {
 		typename Type = real,
 		typename ComplexFunction = std::function<complex<Type>(complex<Type>)>
 	>
-	inline complex<Type> root_newton(
+	inline iter_result<complex<Type>> root_newton(
 		ComplexFunction f, ComplexFunction Df, complex<Type> guess,
 		real tol = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_NEWTON_ITER) {
@@ -321,10 +321,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_newton", z.Re(), MathError::NoConvergence);
-			return complex<Type>(nan(), nan());
+			return iter_result<complex<Type>>(ConvergenceStatus::MaxIterations, iter, f_z.norm());
 		}
 
-		return z;
+		return iter_result<complex<Type>>(z, iter, f_z.norm());
 	}
 
 
@@ -341,7 +341,7 @@ namespace theoretica {
 	/// @return The coordinate of the root of the function,
 	/// or NaN if the algorithm did not converge.
 	template<typename RealFunction>
-	inline real root_halley(
+	inline iter_result<real> root_halley(
 		RealFunction f, RealFunction Df,
 		RealFunction D2f, real guess = 0,
 		real tol = OPTIMIZATION_TOL,
@@ -362,10 +362,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_halley", x, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(f_x));
 		}
 
-		return x;
+		return iter_result<real>(x, iter, abs(f_x));
 	}
 
 
@@ -382,7 +382,7 @@ namespace theoretica {
 	/// the algorithm is assumed to not have converged.
 	/// @return The coordinate of the root of the function,
 	/// or NaN if the algorithm did not converge.
-	inline real root_halley(
+	inline iter_result<real> root_halley(
 		dual2(*f)(dual2), real guess = 0,
 		real tol = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_HALLEY_ITER) {
@@ -407,10 +407,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_halley", x, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(s.Re()));
 		}
 
-		return x;
+		return iter_result<real>(x, iter, abs(s.Re()));
 	}
 
 
@@ -425,7 +425,7 @@ namespace theoretica {
 	/// @return The coordinate of the root of the function,
 	/// or NaN if the algorithm did not converge.
 	template<typename RealFunction>
-	inline real root_steffensen(
+	inline iter_result<real> root_steffensen(
 		RealFunction f, real guess = 0,
 		real tol = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_STEFFENSEN_ITER) {
@@ -445,10 +445,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_steffensen", x, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(f_x));
 		}
 
-		return x;
+		return iter_result<real>(x, iter, abs(f_x));
 	}
 
 
@@ -493,10 +493,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_chebyshev", x, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(f_x));
 		}
 
-		return x;
+		return iter_result<real>(x, iter, abs(f_x));
 	}
 
 
@@ -518,7 +518,7 @@ namespace theoretica {
 	/// when the derivatives of the function are easy to compute, especially
 	/// when using automatic differentiation. For example, the exponential needs to be
 	/// computed only once to evaluate the function and its derivatives.
-	inline real root_chebyshev(
+	inline iter_result<real> root_chebyshev(
 		dual2(*f)(dual2), real guess = 0,
 		real tol = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_CHEBYSHEV_ITER) {
@@ -541,10 +541,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_chebyshev", x, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(s.Re()));
 		}
 
-		return x;
+		return iter_result<real>(x, iter, abs(s.Re()));
 	}
 
 
@@ -565,7 +565,7 @@ namespace theoretica {
 	/// corrective coefficient. This method does not have an overload using
 	/// automatic differentiation as it would hinder the performance benefit.
 	template<typename RealFunction>
-	inline real root_ostrowski(
+	inline iter_result<real> root_ostrowski(
 		RealFunction f, RealFunction Df, real guess = 0.0,
 		real tol = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_OSTROWSKI_ITER) {
@@ -588,10 +588,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_ostrowski", x, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(f_x));
 		}
 
-		return x;
+		return iter_result<real>(x, iter, abs(f_x));
 	}
 
 
@@ -613,7 +613,7 @@ namespace theoretica {
 	/// have an overload using automatic differentiation as it would hinder the
 	/// performance benefit.
 	template<typename RealFunction>
-	inline real root_jarrat(
+	inline iter_result<real> root_jarrat(
 		RealFunction f, RealFunction Df, real guess = 0.0,
 		real tol = OPTIMIZATION_TOL,
 		unsigned int max_iter = OPTIMIZATION_JARRAT_ITER) {
@@ -635,10 +635,10 @@ namespace theoretica {
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_jarrat", x, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, abs(f_x));
 		}
 
-		return x;
+		return iter_result<real>(x, iter, abs(f_x));
 	}
 
 
@@ -656,8 +656,8 @@ namespace theoretica {
 	///
 	/// @note If the number of roots inside the interval is completely unknown,
 	/// using many more steps should be preferred, to ensure all roots are found.
-	template<typename RealFunction>
-	inline std::vector<real> roots(
+	template<typename RealFunction, typename Vector = vec<real>>
+	inline Vector roots(
 		RealFunction f, real a, real b,
 		real tol = OPTIMIZATION_TOL, real steps = 10) {
 
@@ -667,10 +667,11 @@ namespace theoretica {
 		}
 
 		// Find candidate intervals
-		std::vector<vec2> intervals = find_root_intervals(f, a, b, steps);
+		auto intervals = find_root_intervals(f, a, b, steps);
 
-		std::vector<real> res;
-		res.reserve(intervals.size());
+		Vector res;
+		res.resize(intervals.size());
+		size_t idx = 0;
 
 		// Iterate through all candidate intervals and refine the results
 		for (unsigned int i = 0; i < intervals.size(); ++i) {
@@ -678,21 +679,28 @@ namespace theoretica {
 			// Check whether the extremes of the candidate intervals
 			// happen to coincide with the roots
 			if(abs(f(intervals[i][0])) <= MACH_EPSILON) {
-				res.push_back(intervals[i][0]);
+				res[idx] = intervals[i][0];
+				idx++;
 				continue;
 			}
 
 			if(abs(f(intervals[i][1])) <= MACH_EPSILON) {
-				res.push_back(intervals[i][1]);
+				res[idx] = intervals[i][1];
+				idx++;
 				continue;
 			}
 
 			// Approximate the roots using bisection inside each interval
-			res.push_back(
-				root_bisect(f, intervals[i][0], intervals[i][1], tol)
-			);
+			real r = root_bisect(f, intervals[i][0], intervals[i][1], tol);
+
+			if (!is_nan(r)) {
+				res[idx] = r;
+				idx++;
+			}
 		}
 
+		// Remove extra elements
+		//res.resize(idx);
 		return res;
 	}
 
@@ -700,36 +708,37 @@ namespace theoretica {
 	/// Find all the roots of a polynomial.
 	/// An interval bound on the roots is found using Cauchy's theorem.
 	///
+	/// For polynomials with very unevenly distributed roots, the algorithm may
+	/// fail to find all roots, in this case the steps parameter should be increased
+	/// to ensure all roots are found.
+	///
 	/// @param p The polynomial to search the roots of.
-	/// @param steps The number of steps to use
-	/// (defaults to twice the polynomial's order).
+	/// @param steps The number of steps to use (defaults to 10 times the polynomial's order).
 	/// @return A vector of the roots of the polynomial that were found.
-	template<typename Field>
-	inline std::vector<Field> roots(
-		const polynomial<Field>& p,
-		real tolerance = OPTIMIZATION_TOL,
+	template<typename Field, typename Vector = vec<Field>>
+	inline Vector roots_polynomial(
+		const polynomial<Field>& p, real tolerance = OPTIMIZATION_TOL,
 		unsigned int steps = 0) {
+		
+		// Real polynomial degree
+		const unsigned int p_order = p.find_order();
+		if (p_order == 0) {
+			TH_MATH_ERROR("roots_polynomial", p.coeff[0], MathError::InvalidArgument);
+			return {nan()};
+		}
 
-		// Effective order of the polynomial
-		const unsigned int n = p.find_order();
-		p /= p.coeff[n];
+		// Normalize the polynomial by the leading coefficient to apply Cauchy's bound
+		polynomial<Field> p_norm = p / p.coeff[p_order];
+		Field a_max = 0;
 
-		// Absolute value of the highest coefficient
-		Field a_hi = abs(p.coeff[n]);
-		Field a_sum = 0;
-
-		// Sum the absolute values of the lesser coefficients
-		for (unsigned int i = 0; i < n; ++i)
-			a_sum += abs(p.coeff[i]);
+		// Find the maximum absolute coefficient
+		for (unsigned int i = 0; i < p_order - 1; ++i)
+			a_max = max(a_max, abs(p_norm.coeff[i]));
 
 		// The roots are bounded in absolute value by the maximum
-		const Field M = max(a_hi, a_sum);
+		const Field M = 1 + a_max;
 
-		// Back track from the bounds to the first sign inversion ?
-		
-		return roots(
-			[p](real x) { return p(x); },
-			-M, M, tolerance, steps ? steps : (2 * n));
+		return roots(p_norm, -M, M, tolerance, steps > 0 ? steps : 10 * p_order);
 	}
 
 }

--- a/src/optimization/roots.h
+++ b/src/optimization/roots.h
@@ -12,6 +12,7 @@
 #include "../autodiff/dual2.h"
 #include "../algebra/vec.h"
 #include "../complex/complex.h"
+#include "../core/iter_result.h"
 
 
 namespace theoretica {
@@ -214,27 +215,36 @@ namespace theoretica {
 	/// @return The coordinate of the root of the function,
 	/// or NaN if the algorithm did not converge.
 	template<typename RealFunction>
-	inline real root_newton(
+	inline iter_result<real> root_newton(
 		RealFunction f, RealFunction Df, real guess = 0.0,
 		real tol = OPTIMIZATION_TOL, unsigned int max_iter = OPTIMIZATION_NEWTON_ITER) {
 
 		real x = guess;
 		real f_x = inf();
+		real Df_x = 0;
 		unsigned int iter = 0;
 
 		while(abs(f_x) > tol && iter <= max_iter) {
 
+			Df_x = Df(x);
+
+			// Check for division by zero
+			if (abs(Df_x) < MACH_EPSILON) {
+				TH_MATH_ERROR("root_newton", Df_x, DIV_BY_ZERO);
+				return iter_result<real>(ConvergenceStatus::Diverged, iter, Df_x);
+			}
+
 			f_x = f(x);
-			x = x - (f_x / Df(x));
+			x = x - (f_x / Df_x);
 			iter++;
 		}
 
 		if(iter > max_iter) {
 			TH_MATH_ERROR("root_newton", x, MathError::NoConvergence);
-			return nan();
+			return iter_result<real>(ConvergenceStatus::MaxIterations, iter, Df_x);
 		}
 
-		return x;
+		return iter_result<real>(x, iter, f_x);
 	}
 
 


### PR DESCRIPTION
- Add a new `iter_result` class which contains information about the convergence status of an algorithm, such as its result, final status (success, algorithm diverged, invalid input ...) and final residual.
- Change root and extrema finding functions to use the new class